### PR TITLE
Update runExample.sh

### DIFF
--- a/script/runExample.sh
+++ b/script/runExample.sh
@@ -21,7 +21,7 @@ echo "=============== Index Docs ============="
 dwid_pt=${output_dir}doc_wids.txt
 # vocabulary file
 voca_pt=${output_dir}voca.txt
-python indexDocs.py $doc_pt $dwid_pt $voca_pt
+python3 indexDocs.py $doc_pt $dwid_pt $voca_pt
 
 ## learning parameters p(z) and p(w|z)
 echo "=============== Topic Learning ============="
@@ -37,4 +37,4 @@ echo "../src/btm inf sum_b $K $dwid_pt $model_dir"
 
 ## output top words of each topic
 echo "================ Topic Display ============="
-python topicDisplay.py $model_dir $K $voca_pt
+python3 topicDisplay.py $model_dir $K $voca_pt


### PR DESCRIPTION
Fix compilation issues related to calling python via `python` which may call the incompatible python 2. Now it uses `python3` explicitly. It relates to #13.